### PR TITLE
Feature/post user

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -10,6 +10,10 @@ app.use(cors({ origin: FRONTEND_URL }));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+const users = [
+    {id: "id1", username: "test1" }
+];
+
 try {
     app.listen(PORT, () => {
         console.log(`server running at: //localhost:${PORT}`);
@@ -22,7 +26,7 @@ try {
 
 app.get('/', (req: Request, res: Response) => {
     console.log("getリクエストを受け付けました");
-    return res.status(200).json({ message: 'Hello World' });
+    return res.status(200).json({ users });
 });
 
 app.post('/user/register', (req: Request, res: Response) => {

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,11 +1,14 @@
 import express, { Application, Request, Response } from 'express';
 import cors from 'cors';
+import { uid } from 'uid';
 
 const app: Application = express();
 const PORT: number = 3000;
 const FRONTEND_URL: string = "http://localhost:5173";
 
 app.use(cors({ origin: FRONTEND_URL }));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 try {
     app.listen(PORT, () => {
@@ -20,4 +23,12 @@ try {
 app.get('/', (req: Request, res: Response) => {
     console.log("getリクエストを受け付けました");
     return res.status(200).json({ message: 'Hello World' });
+});
+
+app.post('/user/register', (req: Request, res: Response) => {
+    console.log('postリクエストを受け付けました');
+    const { username } = req.body.data;
+    console.log(req.body.data.username);
+    const uidValue = uid();
+    return res.status(200).json({ id: uidValue, username });
 });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "uid": "^2.0.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -56,6 +57,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -1307,6 +1316,17 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "dependencies": {
+        "@lukeed/csprng": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/undefsafe": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
   "license": "ISC",
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "uid": "^2.0.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/qcmx_front/package-lock.json
+++ b/qcmx_front/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.7.2",
         "cors": "^2.8.5",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-hook-form": "^7.52.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -2912,6 +2913,21 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.1.tgz",
+      "integrity": "sha512-uNKIhaoICJ5KQALYZ4TOaOLElyM+xipord+Ha3crEFhTntdLvWZqVY49Wqd/0GiVCA/f9NjemLeiNPjG7Hpurg==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-refresh": {

--- a/qcmx_front/package.json
+++ b/qcmx_front/package.json
@@ -13,7 +13,8 @@
     "axios": "^1.7.2",
     "cors": "^2.8.5",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.52.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/qcmx_front/src/App.tsx
+++ b/qcmx_front/src/App.tsx
@@ -1,18 +1,62 @@
 import axios from 'axios';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import './App.css'
+import { useForm } from 'react-hook-form';
+
+const BACKEND_URL: string = "http://localhost:3000";
+
+type UserType = {
+  id: string;
+  username: string;
+}
+
+type UserRegisterFormType = {
+  username: string;
+}
 
 const Home: React.FC = () => {
+
+  const { register, handleSubmit } = useForm<UserRegisterFormType>();
+  
+  const [users, setUsers] = useState<UserType[]>([]);
+
+  const addUser = async (event: UserRegisterFormType) => {
+    const { username } = event;
+    console.log(username);
+    await axios.post(`${BACKEND_URL}/user/register`, {
+              data: { username }
+            })
+            .then((response) => {
+              console.log(response.data);
+              const username = response.data;
+              setUsers((_preUsers) => [username, ..._preUsers]);
+            })
+            .catch((error) => { console.log(error); });
+  }
+
   useEffect(() => {
-    axios.get("http://localhost:3000")
+    axios.get(BACKEND_URL)
       .then((response) => {
-        console.log(response.data.message);
+        console.log(response.data);
+        const { users } = response.data;
+        setUsers(users);
       })
       .catch((e) => {
         console.log(e.message);
       });
   }, []);
 
-  return <div></div>;
+  return (
+    <>
+      <form onSubmit={handleSubmit(addUser)}>
+        <input {...register("username")} type="text" />
+        <button type="submit">add</button>
+      </form>
+      {users.map((user) => (
+        <p key={user.id}>{user.username}</p>
+      ))}
+    </>
+  );
 }
 
 export default Home;


### PR DESCRIPTION
## 概要
ユーザーデータの送受信を実装

## 対応したこと
- 単純構造のユーザーデータをFrontend, Backend間で通信を行う
- ユーザーデータを画面に表示する

## 変更結果
- ユーザーデータのget, postができるようになった

## 使い方
1. 2つのターミナルを立ち上げる
2. 1つ目のターミナルで以下のコマンドを順次実行する
```
cd backend
npm start
```
3. 2つ目のターミナルで以下のコマンドを順次実行する
```
cd qcmx_front
npm run dev
```
### 確認方法
1. [http://localhost:5173/](http://localhost:5173/)にブラウザでアクセスする
2. 検証を開き, コンソールにHello Worldと出力されている

## 関連issue
issue: #3 